### PR TITLE
Add simplify option for languages keys

### DIFF
--- a/tasks/crowdin.js
+++ b/tasks/crowdin.js
@@ -33,10 +33,15 @@ module.exports = function(grunt) {
         var normalize = function(data) {
             var normalized = {};
             forEach(data, function(value, key) {
-                var lang = key.replace('-', '_');
-                lang = lang.replace(/_([a-zA-Z]{2})/, function (match, p) {
-                    return '_' + p.toUpperCase();
-                });
+                var lang = key;
+                // replace codes like es-ES to simply es
+                if (options.simplify && lang.length > 2) {
+                    lang = lang.substr(0, 2);
+                } else {
+                    lang = lang.replace('-', '_').replace(/_([a-zA-Z]{2})/, function (match, p) {
+                        return '_' + p.toUpperCase();
+                    });
+                }
                 normalized[ lang ] = value;
             });
             return normalized;


### PR DESCRIPTION
Make it possible to generate languages files with two letters codes only.
For example `es.json` instead of `es_ES.json`

This option is backward compatible as it doesn't change behavior (default = false)
Just add a `simplify: true` to the options list to use it
